### PR TITLE
Fix Claude review auth: use oauth token parameter

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,5 +35,4 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          # optional: claude_args: '--mode tag'
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
The secret was passed as `anthropic_api_key` but it's an OAuth token. This caused `Could not resolve authentication` SDK errors. Switching to `claude_code_oauth_token`.