### PR TITLE
Allow bbqs-agent Cloudflare Workers domain in Globus auth

### DIFF
--- a/supabase/functions/globus-auth/index.ts
+++ b/supabase/functions/globus-auth/index.ts
@@ -324,11 +324,14 @@ Deno.serve(async (req) => {
         "https://www.brain-bbqs.org",
         "https://brain-bbqs.github.io",
         "https://brain-bbq-clone.lovable.app",
+        // bbqs-agent (Cloudflare Workers) — add the deployed workers.dev URL here once known
+        // e.g. "https://tanstack-start-app.ACCOUNT.workers.dev",
         "http://localhost:",
       ];
       const isAllowedRedirect = redirect_uri && ALLOWED_REDIRECT_ORIGINS.some(
         (o: string) => redirect_uri.startsWith(o)
-      ) || (redirect_uri && /^https:\/\/[a-z0-9-]+\.lovable\.app\//.test(redirect_uri));
+      ) || (redirect_uri && /^https:\/\/[a-z0-9-]+\.lovable\.app\//.test(redirect_uri))
+        || (redirect_uri && /^https:\/\/[a-z0-9-]+\.workers\.dev\//.test(redirect_uri));
 
       if (!isAllowedRedirect) {
         return new Response(JSON.stringify({ error: "Invalid redirect_uri" }), {


### PR DESCRIPTION
## Summary

- Adds `*.workers.dev` to the allowed redirect origins in the `globus-auth` edge function
- Enables the bbqs-agent companion app (deployed on Cloudflare Workers) to reuse the same Globus OAuth flow and membership gate as brain-bbqs.org

## Details

The bbqs-agent app calls this edge function with its own `redirect_uri` pointing back to its Cloudflare Workers domain. Without this change the edge function rejects the redirect with `Invalid redirect_uri`.

Once the specific Workers deployment URL is confirmed, add it explicitly to `ALLOWED_REDIRECT_ORIGINS` alongside the regex.

## Test plan

- [ ] Globus login initiated from bbqs-agent completes successfully
- [ ] Existing brain-bbqs.org login flow is unaffected