### PR TITLE
dev → main: feature lock phase 0, E2E fixes, investigator deep links

### DIFF
--- a/src/data/sidebar-config.ts
+++ b/src/data/sidebar-config.ts
@@ -55,7 +55,7 @@ const knowledgeBaseItems: NavItem[] = [
   { title: "Grants", url: "/grants", icon: Globe },
   { title: "Species", url: "/species", icon: Bug },
   { title: "Publications", url: "/publications", icon: FileText },
-  { title: "Data Provenance", url: "/data-provenance", icon: History },
+  { title: "Data Provenance", url: "/data-provenance", icon: History, disabled: true },
 ];
 
 const communityItems: NavItem[] = [
@@ -63,7 +63,7 @@ const communityItems: NavItem[] = [
   { title: "Working Groups", url: "/working-groups", icon: Users },
   { title: "Announcements", url: "/announcements", icon: Bell },
   { title: "Job Board", url: "/jobs", icon: Briefcase },
-  { title: "Calendar", url: "/calendar", icon: CalendarDays },
+  { title: "Calendar", url: "/calendar", icon: CalendarDays, authRequired: true },
 ];
 
 const conferencesItems: NavItem[] = [

--- a/src/pages/PrincipalInvestigators.tsx
+++ b/src/pages/PrincipalInvestigators.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from "react-router-dom";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { MobileCardList } from "@/components/MobileCardList";
 import { AgGridReact } from "ag-grid-react";
@@ -623,18 +623,37 @@ const WG_FILTERS: { id: WgFilter; label: string }[] = [
 export default function PrincipalInvestigators() {
   const [searchParams] = useSearchParams();
   const [quickFilterText, setQuickFilterText] = useState(searchParams.get("q") || "");
+  const qParam = useMemo(() => searchParams.get("q"), []); // stable: read once on mount
   const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
   const [wgFilter, setWgFilter] = useState<WgFilter>("all");
   const [visibleColumns, setVisibleColumns] = useState<Set<ColumnId>>(
     () => new Set(ALL_COLUMNS.filter(c => c.default).map(c => c.id))
   );
 
+  const { open } = useEntitySummary();
   const { data: rawRowData = [], isLoading } = useQuery({
     queryKey: ["principal-investigators"],
     queryFn: fetchPIs,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });
+
+  // Auto-open entity summary when page is opened via a ?q=Name deep link
+  // (e.g. from an agent investigator chip). Fires once after data loads.
+  const autoOpenFired = useRef(false);
+  useEffect(() => {
+    if (!qParam || rawRowData.length === 0 || autoOpenFired.current) return;
+    autoOpenFired.current = true;
+    const qNorm = nameKey(qParam);
+    const match = rawRowData.find(
+      (pi) =>
+        nameKey(pi.displayName).includes(qNorm) ||
+        nameKey(pi.name).includes(qNorm),
+    );
+    if (match) {
+      open({ type: "investigator", id: match.id, resourceId: match.resourceId, label: match.displayName });
+    }
+  }, [rawRowData]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const rowData = useMemo(() => {
     let filtered = rawRowData;


### PR DESCRIPTION
## Summary

- **Continuous scroll** on Projects, Publications, Resources, Species, People — AG Grid pagination removed; all rows load at once
- **Add Resource form** (`/resources`): curator-gated modal to propose new resources; goes through `pending_writes` review flow
- **Add Publication form** (`/publications`): member-gated modal to propose new publications; same review flow
- **Resource category restructure**: categories deduplicated and grouped (Software, Datasets, Models, Protocols, Benchmarks)
- **Feature locking**:
  - Calendar is now auth-gated — requires sign-in (contains privileged consortium info)
  - Data Provenance disabled in sidebar (greyed out) — page doesn't load usable content yet
- **Investigator deep links**: clicking an investigator chip in the agent chat now auto-opens that person's entity summary panel on `/investigators?q=Name` — implemented via a `?q=` URL param effect in `PrincipalInvestigators.tsx`
- **E2E CI fixes**: all 4 Playwright spec files passing — fixed console noise filters, removed non-existent table references, fixed entity summary modal selector (`data-testid` instead of `role="dialog"`), scoped broken-image check to same-origin only
- **Deployment**: removed Cloudflare Pages workflow (Lovable handles `dev` branch deploys directly)

## Test plan

- [ ] `/resources` — curator user sees "Add Resource" button; form submits proposal; non-curator does not see button
- [ ] `/publications` — member user sees "Add Publication" button
- [ ] `/investigators?q=Jane+Smith` — entity summary panel auto-opens for matching investigator
- [ ] Calendar link in sidebar requires sign-in
- [ ] Data Provenance link is greyed out and non-clickable
- [ ] CI passes on this PR (`npm run e2e` all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)