### PR TITLE
fix(e2e): CI green — remove hidden route, fix continuous-scroll timeout

### DIFF
--- a/e2e/console-errors.spec.ts
+++ b/e2e/console-errors.spec.ts
@@ -30,8 +30,8 @@ const ROUTES = [
   "/sfn-2025",
   "/mit-workshop-2026",
   // "/mit-workshop-2026/travel" — sub-page with no h1; excluded until page adds one
-  "/cross-species-synchronization",
-  // "/data-provenance" — page currently has no h1 element; excluded until fixed
+  // "/cross-species-synchronization" — hidden in v1.0.0 (renders NotFound); excluded
+  // "/data-provenance" — disabled in v1.0.0 (no h1); excluded until fixed
 ];
 
 const IGNORED_CONSOLE = [

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -19,7 +19,9 @@ for (const { path, heading } of CRITICAL_PAGES) {
     const errors: string[] = [];
     page.on("pageerror", (err) => errors.push(err.message));
 
-    await page.goto(path, { waitUntil: "networkidle" });
+    // Use "domcontentloaded" — continuous-scroll pages fetch all rows asynchronously
+    // and never reach networkidle within the default 30s timeout.
+    await page.goto(path, { waitUntil: "domcontentloaded" });
 
     // Should have an h1
     const h1 = page.locator("h1").first();
@@ -32,7 +34,7 @@ for (const { path, heading } of CRITICAL_PAGES) {
 }
 
 test("smoke: sidebar navigation works", async ({ page }) => {
-  await page.goto("/", { waitUntil: "networkidle" });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
 
   // Open sidebar if collapsed (mobile)
   const trigger = page.locator("[data-sidebar='trigger']").first();


### PR DESCRIPTION
## Fixes two QA failures introduced after merging PR #171

### 1. `/cross-species-synchronization` → NotFound (console-errors.spec.ts)
Lovable hid this page in v1.0.0 — it now renders the 404 component. Removed from the `ROUTES` list with a comment explaining why.

### 2. `/projects` timeout (smoke.spec.ts)
Continuous scroll (added in v1.0.0) loads all project rows at once via async Supabase fetches. The page never reaches `networkidle` within Playwright's 30s default timeout. Switched to `waitUntil: "domcontentloaded"` — the h1 check already has its own 10s timeout for React hydration, so this is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)