### PR TITLE
fix(ci): skip backup commit when same-date files already exist

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -74,7 +74,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add kg/
-          git commit -m "backup: KG ${{ steps.ts.outputs.DATE }}"
+          git diff --staged --quiet || git commit -m "backup: KG ${{ steps.ts.outputs.DATE }}"
           git push
 
       - name: Summary


### PR DESCRIPTION
## Summary
- Adds `git diff --staged --quiet ||` guard before `git commit` in the nightly backup workflow
- Prevents the workflow from failing with "nothing to commit" when the same-date backup files already exist in `bbqs-backups` (e.g., if the workflow is re-triggered on the same day)
- The `git push` still runs unconditionally so a no-op day is a clean success

## Test plan
- [ ] Trigger the backup workflow twice on the same day — second run should succeed (exit 0) with no new commit
- [ ] Trigger on a new day — a new commit with today's date should appear in `brain-bbqs/bbqs-backups/kg/`