### PR TITLE
feat(onboarding): add onboarding tracking columns to KG

### DIFF
--- a/supabase/migrations/20260520120000_onboarding_tracking.sql
+++ b/supabase/migrations/20260520120000_onboarding_tracking.sql
@@ -1,0 +1,33 @@
+-- Onboarding tracking columns for investigators and projects.
+-- Enables the BBQS agent to track per-step onboarding progress
+-- and surface a pipeline dashboard to admins.
+
+-- ============================================================
+-- investigators: onboarding checklist + completion timestamp
+-- ============================================================
+ALTER TABLE public.investigators
+  ADD COLUMN IF NOT EXISTS onboarding_checklist JSONB DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS onboarding_completed_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.investigators.onboarding_checklist IS
+  'JSON object tracking per-step onboarding status. Keys: pre_check, welcome_email, kg_created, pi_group, consortium_group, wg_groups, data_questionnaire, slack. Values: not_started | pending | done | skipped';
+
+COMMENT ON COLUMN public.investigators.onboarding_completed_at IS
+  'Set when all required onboarding steps are done. NULL = onboarding still in progress.';
+
+-- ============================================================
+-- projects: project-level onboarding status
+-- ============================================================
+ALTER TABLE public.projects
+  ADD COLUMN IF NOT EXISTS onboarding_status TEXT DEFAULT 'not_started'
+    CHECK (onboarding_status IN ('not_started', 'in_progress', 'completed', 'archived'));
+
+COMMENT ON COLUMN public.projects.onboarding_status IS
+  'Lifecycle stage of project onboarding. Updated as investigators and questionnaire are completed.';
+
+-- ============================================================
+-- Index: fast lookup of incomplete onboardings
+-- ============================================================
+CREATE INDEX IF NOT EXISTS investigators_onboarding_incomplete_idx
+  ON public.investigators (created_at DESC)
+  WHERE onboarding_completed_at IS NULL;


### PR DESCRIPTION
## Summary
Adds database columns to support the Phase 1 onboarding automation in bbqs-agent.

## Changes

**Migration: `supabase/migrations/20260520120000_onboarding_tracking.sql`**

### `investigators` table
- `onboarding_checklist JSONB DEFAULT '{}'` — tracks per-step status. Keys: `pre_check`, `welcome_email`, `kg_created`, `pi_group`, `consortium_group`, `wg_groups`, `data_questionnaire`, `slack`. Values: `not_started | pending | done | skipped`
- `onboarding_completed_at TIMESTAMPTZ` — set when all required steps are done; NULL = still in progress

### `projects` table
- `onboarding_status TEXT DEFAULT 'not_started'` — enum: `not_started | in_progress | completed | archived`

### Index
- `investigators_onboarding_incomplete_idx` on `created_at DESC WHERE onboarding_completed_at IS NULL` — for fast pipeline queries

## How it's used
The bbqs-agent writes to these columns via the `onboardingStepPatch` write surface (upstream RLS enforced). The `listOnboardingPipeline` and `getOnboardingChecklist` admin tools query them to provide the pipeline dashboard.

## Test plan
- [ ] Migration applies cleanly on staging
- [ ] `investigators.onboarding_checklist` defaults to `{}`
- [ ] `projects.onboarding_status` defaults to `not_started`
- [ ] Agent `onboardingStepPatch` surface updates `onboarding_checklist` correctly
- [ ] Index used in `listOnboardingPipeline` query (EXPLAIN ANALYZE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)