### PR TITLE
CI: one-click prod KG migration apply + drift list

### DIFF
--- a/.github/workflows/sync-prod-schema.yml
+++ b/.github/workflows/sync-prod-schema.yml
@@ -1,0 +1,66 @@
+name: Apply prod schema (KG)
+
+# Applies committed migrations to the PRODUCTION Knowledge Graph Supabase project
+# (vpexxhfpvghlejljwpvt).
+#
+# WHY THIS EXISTS: KG migrations were applied by hand and kept getting forgotten,
+# leaving the live DB missing enums/columns that already-deployed code used — e.g.
+# `resource_type 'funding'` → "invalid input value for enum resource_type" on Apply.
+# That class of "code shipped, migration didn't" caused repeated dead-end debugging.
+# This gives a reliable, credential-free way to (a) SEE pending migrations (drift)
+# and (b) apply them with one click.
+#
+# Uses SUPABASE_KG_DB_URL — the SAME direct connection string the nightly db-backup
+# uses (known good), so no extra secret/setup is required.
+#
+# SAFETY:
+#   • Never auto-applies on push UNLESS repo variable PROD_MIGRATIONS_ENABLED == 'true'.
+#   • Manual dispatch defaults to dry_run = true → it only LISTS pending migrations,
+#     changes nothing. Set dry_run = false to actually push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List pending migrations only (no changes)'
+        type: boolean
+        default: true
+
+concurrency:
+  group: prod-schema
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    # Auto-runs on push ONLY when explicitly enabled; manual dispatch always allowed.
+    if: ${{ vars.PROD_MIGRATIONS_ENABLED == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify DB URL secret is present
+        run: '[ -n "$DB_URL" ] || { echo "::error::Missing secret SUPABASE_KG_DB_URL"; exit 1; }'
+        env:
+          DB_URL: ${{ secrets.SUPABASE_KG_DB_URL }}
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: List pending migrations (drift report)
+        continue-on-error: true
+        run: supabase migration list --db-url "$DB_URL"
+        env:
+          DB_URL: ${{ secrets.SUPABASE_KG_DB_URL }}
+
+      - name: Push migrations to prod
+        # Push on a real push to main (when enabled) OR a manual dispatch with dry_run=false.
+        if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
+        run: supabase db push --db-url "$DB_URL" --include-all
+        env:
+          DB_URL: ${{ secrets.SUPABASE_KG_DB_URL }}


### PR DESCRIPTION
Adds `.github/workflows/sync-prod-schema.yml` — a reliable, credential-free way to LIST pending KG migrations and APPLY them to prod (vpexxhfpvghlejljwpvt), using the known-good `SUPABASE_KG_DB_URL`.

Why: KG migrations were applied by hand and kept getting forgotten, leaving the live DB missing enums/columns deployed code already used (e.g. `resource_type 'funding'` → invalid-enum on Apply). Mirrors `sync-staging-schema.yml` but for prod.

Safety: lists drift always; only PUSHES on manual dispatch with `dry_run=false` (or auto, once repo var `PROD_MIGRATIONS_ENABLED=true`). Never auto-applies otherwise.

After merge: Actions → "Apply prod schema (KG)" → Run workflow with dry_run=true to see drift, then dry_run=false to apply (this lands the pending `funding` enum migration).